### PR TITLE
Slight simplification in scale factor computation

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -753,19 +753,14 @@ INLINE int evaluate_scale_factor(const Pos *pos, EvalInfo *ei, Value eg)
 
   // If scale is not already specific, scale down via general heuristics
   if (sf == SCALE_FACTOR_NORMAL) {
-    if (opposite_bishops(pos)) {
+    if (   opposite_bishops(pos)
+        && pos_non_pawn_material(WHITE) == BishopValueMg
+        && pos_non_pawn_material(BLACK) == BishopValueMg)
       // Endgame with opposite-colored bishops and no other pieces
       // (ignoring pawns) is almost a draw.
-      if (   pos_non_pawn_material(WHITE) == BishopValueMg
-          && pos_non_pawn_material(BLACK) == BishopValueMg)
         return 31;
-
-      // Endgame with opposite-colored bishops, but also other pieces. Still
-      // a bit drawish, but not as drawish as with only the two bishops.
-      return 46;
-    }
     else
-      return min(40 + 7 * piece_count(strongSide, PAWN), sf);
+      return min(40 + (opposite_bishops(pos) ? 2 : 7) * piece_count(strongSide, PAWN), sf);
   }
 
   return sf;


### PR DESCRIPTION
[STC](http://tests.stockfishchess.org/tests/view/5b2614000ebc5902b8d17193)
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 17733 W: 3996 L: 3866 D: 9871

[LTC](http://tests.stockfishchess.org/tests/view/5b264d0f0ebc5902b8d17206)
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 55524 W: 9535 L: 9471 D: 36518

Use pawn count scaling also for opposite bishops endings with additional material, with a slope of 2 instead of 7. This simplifies slightly the code.

This PR is a functionally equivalent refactoring of the version which was submitted.

Four versions tried, 2 passed both STC and LTC. I picked the one which seemed more promising at LTC.

Slope 4 passed STC (-0.54 Elo), LTC not attempted
Slope 3 passed STC (+2.51 Elo), LTC (-0.44 Elo)
Slope 2 passed STC (+2.09 Elo), LTC (+0.04 Elo)
Slope 1 passed STC (+0.90 Elo), failed LTC (-3.40 Elo)

Bench: 4761613